### PR TITLE
Added delete key action and prefix filter with timer

### DIFF
--- a/UnoStandardRefTest2/UnoStandardRefTest2.Shared/APTest.cs
+++ b/UnoStandardRefTest2/UnoStandardRefTest2.Shared/APTest.cs
@@ -1,19 +1,41 @@
-﻿using Windows.System;
+﻿using System;
+using System.Linq;
+using System.Collections;
+using Windows.System;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
+using Uno.Extensions.Specialized;
+using System.Timers;
 
 namespace UnoStandardRefTest2.Shared
 {
     public class APTest 
     {
+        private static Timer aTimer = new Timer(2000);
+
+        private static string prefixFilter = "";
+
         public static readonly DependencyProperty KeyAwareProperty = DependencyProperty.RegisterAttached(
-            "KeyAware", typeof(bool), typeof(APTest), new PropertyMetadata(KeyAwareChanged));
+            "KeyAware", typeof(bool), typeof(APTest), new PropertyMetadata(null, KeyAwareChanged));
+
+        static APTest()
+        {
+            aTimer.Elapsed += ResetPrefix;
+            aTimer.AutoReset = false;
+            aTimer.Enabled = true;
+        }
+
+        static void ResetPrefix(Object source, ElapsedEventArgs e)
+        {
+            Console.WriteLine("Prefix reset");
+            prefixFilter = "";
+        }
 
         static void KeyAwareChanged(DependencyObject dependencyobject, DependencyPropertyChangedEventArgs args)
         {
             var box = dependencyobject as ComboBox;
-            if ((bool) args.NewValue)
+            if ((bool)args.NewValue)
             {
                 HookKeys(box);
             }
@@ -27,25 +49,76 @@ namespace UnoStandardRefTest2.Shared
 
         static void ComboBoxKeyDown(object sender, KeyRoutedEventArgs e)
         {
-            var comboBox = (ComboBox) sender;
+            var comboBox = (ComboBox)sender;
+            var items = comboBox.ItemsSource as ICollection;
             if (e.Key == VirtualKey.Space)
             {
                 comboBox.IsDropDownOpen = !comboBox.IsDropDownOpen;
             }
-            if (e.Key == VirtualKey.Down)
+            else if (e.Key == VirtualKey.Up)
             {
                 if (comboBox.IsDropDownOpen)
                 {
-                    comboBox.SelectedIndex++;
+                    var selectedIndex = (comboBox.SelectedIndex - 1) % items.Count;
+                    if (selectedIndex < 0)
+                    {
+                        selectedIndex = items.Count - 1;
+                    }
+
+                    comboBox.SelectedIndex = selectedIndex;
                 }
             }
-            if (e.Key == VirtualKey.Up)
+            else if (e.Key == VirtualKey.Down)
             {
-                if (comboBox.IsDropDownOpen && comboBox.SelectedIndex > 0)
+                if (comboBox.IsDropDownOpen)
                 {
-                    comboBox.SelectedIndex--;
+                    var selectedIndex = (comboBox.SelectedIndex + 1) % items.Count;
+                    if (selectedIndex >= items.Count)
+                    {
+                        selectedIndex = 0;
+                    }
+
+                    comboBox.SelectedIndex = selectedIndex;
                 }
             }
+            else if (e.Key == VirtualKey.Delete)
+            {
+                comboBox.SelectedIndex = -1;
+                comboBox.SelectedItem = null;
+                comboBox.IsDropDownOpen = false;
+            }
+            else
+            {
+                FilterSelection(comboBox, items, e.Key);
+            }
+        }
+
+        static void FilterSelection(ComboBox comboBox, ICollection items, VirtualKey key)
+        {
+            aTimer.Stop();
+            Console.WriteLine($"Filtering selection of {items.Count} items");
+            var stringRepresentation = key.ToString();
+            Console.WriteLine($"prefix: {prefixFilter}");
+            prefixFilter = prefixFilter + stringRepresentation;
+            Console.WriteLine($"New prefix: {prefixFilter}");
+            Console.WriteLine($"string representation is {stringRepresentation}");
+            var bestMatch = items.Where(item => ((string)item).StartsWith(prefixFilter, StringComparison.InvariantCultureIgnoreCase)).ElementAt(0);
+            if (bestMatch != null)
+            {
+                Console.WriteLine("Filtering selection");
+                var bestIndex = items.IndexOf(bestMatch);
+                Console.WriteLine($"best index is {bestIndex}");
+                comboBox.SelectedIndex = bestIndex;
+                comboBox.IsDropDownOpen = true;
+            }
+            else
+            {
+                Console.WriteLine("There is no best match");
+                comboBox.SelectedIndex = -1;
+                comboBox.IsDropDownOpen = true;
+            }
+
+            aTimer.Start();
         }
 
         public static void SetKeyAware(DependencyObject element, bool value)
@@ -55,7 +128,7 @@ namespace UnoStandardRefTest2.Shared
 
         public static bool GetKeyAware(DependencyObject element)
         {
-            return (bool) element.GetValue(KeyAwareProperty);
+            return (bool)element.GetValue(KeyAwareProperty);
         }
     }
 }

--- a/UnoStandardRefTest2/UnoStandardRefTest2.Shared/MainPage.xaml
+++ b/UnoStandardRefTest2/UnoStandardRefTest2.Shared/MainPage.xaml
@@ -8,7 +8,7 @@
     xmlns:shared="clr-namespace:UnoStandardRefTest2.Shared"
     xmlns:wasm="http://uno.ui/wasm"
     xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    mc:Ignorable="d wasm win">
+    mc:Ignorable="d wasm">
     <Page.Resources>
         <DataTemplate x:Key="dataTemplate">
             <Button Margin="5" Height="50" Width="250">
@@ -18,11 +18,12 @@
             </Button>
         </DataTemplate>
     </Page.Resources>
+
     <StackPanel Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
         <TextBox/>
-        <win:ComboBox ItemsSource="{Binding Items}" >
+        <win:ComboBox x:Name="comboBoxWin" ItemsSource="{Binding Items}" >
         </win:ComboBox>
-        <wasm:ComboBox ItemsSource="{Binding Items}" shared:APTest.KeyAware="True">
+        <wasm:ComboBox x:Name="comboBoxWasm" ItemsSource="{Binding Items}" shared:APTest.KeyAware="True">
         </wasm:ComboBox>
     </StackPanel>
 </Page>

--- a/UnoStandardRefTest2/UnoStandardRefTest2.Shared/MainPage.xaml.cs
+++ b/UnoStandardRefTest2/UnoStandardRefTest2.Shared/MainPage.xaml.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices.WindowsRuntime;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
@@ -18,43 +18,81 @@ using Windows.UI.Xaml.Navigation;
 #if __WASM__
 using Uno.Extensions;
 #endif
-// The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=402352&clcid=0x409
 
 namespace UnoStandardRefTest2
 {
     /// <summary>
     /// An empty page that can be used on its own or navigated to within a Frame.
     /// </summary>
-    public sealed partial class MainPage : Page
+    public sealed partial class MainPage : Page, INotifyPropertyChanged
     {
+        private ComboBox comboBox;
+
         public MainPage()
         {
-            Items = Enumerable.Range(0, 5).Select(i => i.ToString()).ToList();
-            //            Items = Enumerable.Range(0, 2000).Select(i => i.ToString()).ToList();
             this.InitializeComponent();
             DataContext = this;
+            //Items = Enumerable.Range(0, 5).Select(i => i.ToString()).ToList();
+            Items = new List<string>
+            {
+                "abcstring1",
+                "xyzstring2",
+                "pstring3",
+                "jstring4",
+                "string5",
+            };
 #if __WASM__
-//            var keyDownHandler = new KeyEventHandler(OnMenuBarItemKeyDown);
-//            AddHandler(UIElement.KeyDownEvent, keyDownHandler, true);
-//            comboBox.AddHandler(UIElement.KeyDownEvent, keyDownHandler, true);
-            //            this.RegisterHtmlEventHandler("keydown", OnSimpleEvent);
+            comboBox = comboBoxWasm;
+            //var keyDownHandler = new KeyEventHandler(OnMenuBarItemKeyDown);
+            //AddHandler(UIElement.KeyDownEvent, keyDownHandler, true);
+            //comboBox.AddHandler(UIElement.KeyDownEvent, keyDownHandler, true);
+            //this.RegisterHtmlEventHandler("keydown", OnSimpleEvent);
+#else
+            comboBox = comboBoxWin;
 #endif
         }
 
-//        void OnMenuBarItemKeyDown(object sender, KeyRoutedEventArgs e)
-//        {
-//            if (e.Key == VirtualKey.Space)
-//            {
-//                comboBox.IsDropDownOpen = !comboBox.IsDropDownOpen;
-//            }
-//            if (e.Key == VirtualKey.Down)
-//            {
-//                if (comboBox.IsDropDownOpen)
-//                {
-//                    comboBox.SelectedIndex++;
-//                }
-//            }
-//        }
+        void OnMenuBarItemKeyDown(object sender, KeyRoutedEventArgs e)
+        {
+            //Console.WriteLine($"Key {e.Key} was pressed");
+            //if (e.Key == VirtualKey.Space)
+            //{
+            //    Console.WriteLine("ComboBox should open");
+            //    comboBox.IsDropDownOpen = !comboBox.IsDropDownOpen;
+            //}
+
+            //if (e.Key == VirtualKey.Up)
+            //{
+            //    if (comboBox.IsDropDownOpen)
+            //    {
+            //        var selectedIndex = (comboBox.SelectedIndex - 1) % Items.Count;
+            //        if (selectedIndex < 0)
+            //        {
+            //            selectedIndex = Items.Count - 1;
+            //        }
+
+            //        comboBox.SelectedIndex = selectedIndex;
+            //    }
+            //}
+            //if (e.Key == VirtualKey.Down)
+            //{
+            //    if (comboBox.IsDropDownOpen)
+            //    {
+            //        var selectedIndex = (comboBox.SelectedIndex + 1) % Items.Count;
+            //        if (selectedIndex >= Items.Count)
+            //        {
+            //            selectedIndex = 0;
+            //        }
+
+            //        comboBox.SelectedIndex = selectedIndex;
+            //    }
+            //}
+            //if (e.Key == VirtualKey.Delete || e.Key == VirtualKey.Back)
+            //{
+            //    comboBox.SelectedItem = null;
+            //    comboBox.IsDropDownOpen = false;
+            //}
+        }
 
 #if __WASM__
         private void OnSimpleEvent(object sender, EventArgs e)
@@ -67,7 +105,22 @@ namespace UnoStandardRefTest2
             else Console.WriteLine("e is " + e.GetType());
         }
 #endif
+        private List<string> _items;
+        public List<string> Items
+        {
+            get => _items;
+            set
+            {
+                _items = value;
+                OnPropertyChanged();
+            }
+        }
 
-        public List<string> Items { get; set; }
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        private void OnPropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
     }
 }

--- a/UnoStandardRefTest2/UnoStandardRefTest2.UWP/UnoStandardRefTest2.UWP.csproj
+++ b/UnoStandardRefTest2/UnoStandardRefTest2.UWP/UnoStandardRefTest2.UWP.csproj
@@ -8,10 +8,10 @@
 			you need to make sure that the version provided here matches https://github.com/onovotny/MSBuildSdkExtras/blob/master/Source/MSBuild.Sdk.Extras/DefaultItems/ImplicitPackages.targets#L11.
 			This is not an issue when libraries are referenced through nuget packages. See https://github.com/nventive/Uno/issues/446 for more details.
 			-->
-      <Version>6.2.2</Version>
+      <Version>6.2.8</Version>
     </PackageReference>
     <PackageReference Include="Uno.UI">
-      <Version>1.45.0-dev.1799</Version>
+      <Version>1.46.203-dev.2513</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup>

--- a/UnoStandardRefTest2/UnoStandardRefTest2.Wasm/UnoStandardRefTest2.Wasm.csproj
+++ b/UnoStandardRefTest2/UnoStandardRefTest2.Wasm/UnoStandardRefTest2.Wasm.csproj
@@ -30,8 +30,8 @@
     <Content Include="LinkerConfig.xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Uno.UI" Version="1.45.0-dev.1799" />
-    <PackageReference Include="Uno.Wasm.Bootstrap" Version="1.0.0-dev.293" />
+    <PackageReference Include="Uno.UI" Version="1.46.203-dev.2513" />
+    <PackageReference Include="Uno.Wasm.Bootstrap" Version="1.0.0-dev.302" />
     <DotNetCliToolReference Include="Uno.Wasm.Bootstrap.Cli" Version="1.0.0-dev.137" />
   </ItemGroup>
   <Import Project="..\UnoStandardRefTest2.Shared\UnoStandardRefTest2.Shared.projitems" Label="Shared" Condition="Exists('..\UnoStandardRefTest2.Shared\UnoStandardRefTest2.Shared.projitems')" />


### PR DESCRIPTION
Added the delete key action to deselect what is actually selected and close the dropdown, also, added the prefix filter with timer so the moment any key is pressed is going to be building the prefix within a time lapse of 2 seconds, but there is one problem, actually the prefix is working with the string representation of the VirtualKey, the number string representation is something like 1->Numer1, so the numbers need a new mapping to get the correct string, but apart from that the filter is working.